### PR TITLE
Fix typo with principals identifier

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "this" {
 
         content {
           type        = principals.value.type
-          identifiers = condiprincipalstion.value.identifiers
+          identifiers = principals.value.identifiers
         }
       }
 


### PR DESCRIPTION
## what
* Fixing a typo in principals block 
* 
## why
* Principals block was unusable because of this typo, was always failing with the message `A managed resource "condiprincipalstion" "value" has not been declared in module.test`


