### PR TITLE
change the http provider updates with respect to  3.0.0 version

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled = module.this.enabled
 
-  iam_source_json_url_body = var.iam_source_json_url != null || var.iam_source_json_url == "" ? data.http.iam_source_json_url[0].body : ""
+  iam_source_json_url_body = var.iam_source_json_url != null || var.iam_source_json_url == "" ? data.http.iam_source_json_url[0].response_body : ""
 
   iam_override_policy_documents = var.iam_override_policy_documents == null || var.iam_override_policy_documents == [] ? [] : var.iam_override_policy_documents
   iam_source_policy_documents   = var.iam_source_policy_documents == null || var.iam_source_policy_documents == [] ? [] : var.iam_source_policy_documents


### PR DESCRIPTION
## what

hashicorp `http` provider has deprecated the `body` from [3.0.0](https://github.com/hashicorp/terraform-provider-http/releases/tag/v3.0.0)

## why

```
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/bucket_policy/main.tf line 17, in data "aws_iam_policy_document" "this":
│   17:   source_json = var.iam_source_json_url != null ? data.http.iam_source_json_url[0].body : var.iam_source_json
│ 
│ This object has no argument, nested block, or exported attribute named
│ "body".

```
## references

https://github.com/hashicorp/terraform-provider-http/pull/137

