### PR TITLE
fix: support JSON inputs for policy document when IAM policy/statements are not set as Terraform objects

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,10 +86,6 @@ data "aws_iam_policy_document" "this" {
       condition     = var.iam_policy_statements == null || var.iam_policy == null
       error_message = "Only 1 of var.iam_policy and var.iam_policy_statements may be used, preferably var.iam_policy."
     }
-    precondition {
-      condition     = var.iam_policy_statements != null || var.iam_policy != null || length(local.source_policy_documents) > 0
-      error_message = "Exactly 1 of var.iam_policy and var.iam_policy_statements may be used, preferably var.iam_policy. JSON source policy documents may be used in addition to either of these."
-    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -84,11 +84,11 @@ data "aws_iam_policy_document" "this" {
   lifecycle {
     precondition {
       condition     = var.iam_policy_statements == null || var.iam_policy == null
-      error_message = "Only 1 of var.iam_policy and var.iam_policy_statments may be used, preferably var.iam_policy."
+      error_message = "Only 1 of var.iam_policy and var.iam_policy_statements may be used, preferably var.iam_policy."
     }
     precondition {
-      condition     = var.iam_policy_statements != null || var.iam_policy != null
-      error_message = "Exactly 1 of var.iam_policy and var.iam_policy_statments may be used, preferably var.iam_policy."
+      condition     = var.iam_policy_statements != null || var.iam_policy != null || length(local.source_policy_documents) > 0
+      error_message = "Exactly 1 of var.iam_policy and var.iam_policy_statements may be used, preferably var.iam_policy. JSON source policy documents may be used in addition to either of these."
     }
   }
 }


### PR DESCRIPTION
## what

- Consider JSON source policy documents in the recently added precondition block.

## why

- [It's expected to support JSON inputs](https://github.com/cloudposse/terraform-aws-components/pull/692#discussion_r1205870213) while` var.iam_policy` and `var.iam_policy_statments` may remain unset. The precondition fails in this case:
```
│ Error: Resource precondition failed
│ 
│   on .terraform/modules/iam_policy/main.tf line 90, in data "aws_iam_policy_document" "this":
│   90:       condition     = var.iam_policy_statements != null || var.iam_policy != null
│     ├────────────────
│     │ var.iam_policy is null
│     │ var.iam_policy_statements is null
│ 
│ Exactly 1 of var.iam_policy and var.iam_policy_statments may be used, preferably var.iam_policy.
``` 

## references

- N/A
