### PR TITLE
Remove problematic conditional

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -21,6 +21,9 @@ iam_policy = [{
         "arn:aws:s3:::s3_bucket_name/home/&{aws:username}",
         "arn:aws:s3:::s3_bucket_name/home/&{aws:username}/*",
       ]
+      # We include an empty `principals` attribute to make this object different than the following object,
+      # which makes `statements` a tuple instead of a list.
+      principals = []
       conditions = [
         {
           test     = "StringLike"
@@ -48,9 +51,10 @@ iam_policy = [{
 iam_policy_two = [{
   statements = [
     {
-      sid     = "ListMyBucket"
-      effect  = "Allow"
-      actions = ["s3:ListBucket"]
+      sid        = "ListMyBucket"
+      effect     = "Allow"
+      actions    = ["s3:ListBucket"]
+      principals = []
       resources = [
         "arn:aws:s3:::s3_bucket_name/home/&{aws:username}",
         "arn:aws:s3:::s3_bucket_name/home/&{aws:username}/*",
@@ -83,8 +87,9 @@ iam_policy_two = [{
 
 iam_policy_statements_map = {
   ListMyBucket = {
-    effect  = "Allow"
-    actions = ["s3:ListBucket"]
+    effect     = "Allow"
+    actions    = ["s3:ListBucket"]
+    principals = []
     resources = [
       "arn:aws:s3:::s3_bucket_name/home/&{aws:username}",
       "arn:aws:s3:::s3_bucket_name/home/&{aws:username}/*",
@@ -113,9 +118,10 @@ iam_policy_statements_map = {
 
 iam_policy_statements_list = [
   {
-    sid     = "ListMyBucket"
-    effect  = "Allow"
-    actions = ["s3:ListBucket"]
+    sid        = "ListMyBucket"
+    effect     = "Allow"
+    actions    = ["s3:ListBucket"]
+    principals = []
     resources = [
       "arn:aws:s3:::s3_bucket_name/home/&{aws:username}",
       "arn:aws:s3:::s3_bucket_name/home/&{aws:username}/*",

--- a/variables-deprecated.tf
+++ b/variables-deprecated.tf
@@ -23,7 +23,7 @@ locals {
   # If it is a list, the SID is allowed to be null.
   deprecated_statements_keys   = try(keys(var.iam_policy_statements), [null])
   deprecated_statements_values = try(values(var.iam_policy_statements), var.iam_policy_statements)
-  deprecated_statements_with_sid = !local.enabled || var.iam_policy_statements == null ? [] : [
+  deprecated_statements_with_sid = [
     for i, v in local.deprecated_statements_values :
     merge(v, lookup(v, "sid", null) == null ? { sid = element(local.deprecated_statements_keys, i) } : {})
   ]


### PR DESCRIPTION
## what

- Remove problematic conditional

## why

- `local.deprecated_statements_values` can be a tuple, and Terraform does not have a concept of an empty or null tuple to use as an alternative in a conditional, so you can get an error like:

```
The true and false result expressions must have consistent types. The 'true' tuple has length 0, but the 'false' tuple has length 2.
```

## references

- https://github.com/hashicorp/terraform/issues/33303
