### PR TITLE
feat: support policy attachments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ resource "aws_iam_role_policy_attachment" "default" {
   for_each = local.iam_policy_enabled && var.role_names != null ? toset(var.role_names) : toset([])
 
   role       = each.value
-  policy_arn = one(aws_iam_policy.policy[*].arn)
+  policy_arn = one(aws_iam_policy.default[*].arn)
 }
 
 resource "aws_iam_role_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,12 @@ locals {
   source_policy_documents = compact(concat([local.iam_source_json_url_body], data.aws_iam_policy_document.policy[*].json, local.iam_source_policy_documents))
 
   policy = concat(local.deprecated_policy, var.iam_policy)
+
+  iam_policy_enabled = local.enabled && var.iam_policy_enabled
+
+  iam_inline_policy_enabled = local.enabled && !var.iam_policy_enabled
+
+  policy_json = one(data.aws_iam_policy_document.this[*].json)
 }
 
 data "http" "iam_source_json_url" {
@@ -78,10 +84,26 @@ data "aws_iam_policy_document" "this" {
 }
 
 resource "aws_iam_policy" "default" {
-  count = local.enabled && var.iam_policy_enabled ? 1 : 0
+  count = local.iam_policy_enabled ? 1 : 0
 
   name        = module.this.id
   description = var.description
-  policy      = one(data.aws_iam_policy_document.this[*].json)
+  policy      = local.policy_json
   tags        = module.this.tags
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  for_each = local.iam_policy_enabled && var.role_names != null ? toset(var.role_names) : toset([])
+
+  role       = each.value
+  policy_arn = one(aws_iam_policy.policy[*].arn)
+}
+
+resource "aws_iam_role_policy" "default" {
+  for_each = local.iam_inline_policy_enabled && var.role_names != null ? toset(var.role_names) : toset([])
+
+  name = module.this.id
+  role = each.value
+
+  policy = local.policy_json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,8 +41,19 @@ variable "description" {
 
 variable "iam_policy_enabled" {
   type        = bool
-  description = "If set to `true` will create the IAM policy in AWS, otherwise will only output policy as JSON."
+  description = <<-EOT
+    Whether to create the IAM managed policy in AWS or not.
+    If false without role_names, it will output the JSON policy,
+    with role_names, it will attach the inline policy.
+    EOT
   default     = false
+}
+
+variable "role_names" {
+  type        = list(string)
+  description = <<-EOT
+    IAM role names to attach the policy to
+  default     = null
 }
 
 variable "iam_source_json_url" {
@@ -53,20 +64,6 @@ variable "iam_source_json_url" {
     Statements in this policy will be overridden by statements with the same SID in `iam_override_policy_documents`.
     EOT
   default     = null
-}
-
-variable "role_names" {
-  type        = list(string)
-  description = <<-EOT
-    Role names to attach the policy to
-  default     = null
-}
-
-variable "managed_policy_enabled" {
-  type        = bool
-  description = <<-EOT
-    Whether to create an IAM managed policy or inline policy. If false, provide role_names is required to attach the policy.
-  default     = true
 }
 
 variable "iam_source_policy_documents" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,20 @@ variable "iam_source_json_url" {
   default     = null
 }
 
+variable "role_names" {
+  type        = list(string)
+  description = <<-EOT
+    Role names to attach the policy to
+  default     = null
+}
+
+variable "managed_policy_enabled" {
+  type        = bool
+  description = <<-EOT
+    Whether to create an IAM managed policy or inline policy. If false, provide role_names is required to attach the policy.
+  default     = true
+}
+
 variable "iam_source_policy_documents" {
   type        = list(string)
   description = <<-EOT

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,8 @@ variable "iam_policy_enabled" {
 variable "role_names" {
   type        = list(string)
   description = <<-EOT
-    IAM role names to attach the policy to
+    IAM role names to attach the policy to. Use iam_policy_enabled to toggle between managed or inline.
+    EOT
   default     = null
 }
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- feat: support policy attachments

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- It's very convenient to be able to attach managed policies or attach inline policies to roles in a single module
- All cloudposse modules that use IAM roles and policies have to reinvent this technology and support both inline and managed. For a while, cloudposse defaulted to creating managed policies which isnt best practice. Each module is getting updated to support inline as an option. To make this easier, this module can support a toggle and then this module can be adopted into the other modules to make it easier to support both cases.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes #21 